### PR TITLE
Return image of product while combination doesn't have one (fix PHP7.4 issue)

### DIFF
--- a/controllers/admin/AdminAjaxPs_buybuttonliteController.php
+++ b/controllers/admin/AdminAjaxPs_buybuttonliteController.php
@@ -126,6 +126,9 @@ class AdminAjaxPs_buybuttonliteController extends ModuleAdminController
         $link = new Link();
 
         $image_data = Image::getBestImageAttribute($id_shop, $id_lang, $id_product, $id_product_attribute);
+        if (!is_array($image_data) || !isset($image_data['id_image'])) {
+            return $this->getProductImage($id_product);
+        }
         $id_image = $image_data['id_image'];
 
         $image_link = $link->getImageLink($link_rewrite, $id_image, ImageType::getFormattedName('small'));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix PHP 7.4 notice while there is no image to a combinaton.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes [PrestaShop/ps_buybuttonlite#{62}.](https://github.com/PrestaShop/PrestaShop/issues/29901)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
